### PR TITLE
chore: add support for abortSignals

### DIFF
--- a/src/manager/index-manager.ts
+++ b/src/manager/index-manager.ts
@@ -16,8 +16,8 @@ type CallWebhookPayload<E extends Endpoint> = E extends EndpointSnapshot
     ? any[]
     : E extends EndpointDeploy
       ? undefined
-      : E extends EndpointUpdateSchema 
-        ? { schema: { [key: string]: any }, embeddings?: any }
+      : E extends EndpointUpdateSchema
+        ? { schema: { [key: string]: any }; embeddings?: any }
         : never
 
 export class IndexManager {

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -4,7 +4,7 @@ import { IndexManager } from './index-manager.js'
 import { API_V1_BASE_URL } from './constants.js'
 
 type CloudManagerConfig = {
-  api_key: string,
+  api_key: string
   baseURL?: string
 }
 


### PR DESCRIPTION
This PR adds support for abort signals while retaining support for AbortControllers, since we don't need the controller itself to cancel requests