### PR TITLE
feat: add experimental support for multi index search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oramacloud/client",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "description": "Orama SDK for Node.js, Deno, and Browsers",
   "type": "module",
   "sideEffects": false,

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -1,7 +1,7 @@
 import type { SearchEvent, ICollector, TelemetryConfig } from './types.js'
 import pkg from '../package.json'
 import sendBeacon from './sendBeacon.js'
-import { Profile } from './profile.js'
+import type { Profile } from './profile.js'
 
 type Data = any[]
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,5 +12,7 @@ export const ORAMA_PROXY_CHAT_ENDPOINT = '/chat'
 export const ORAMA_PROXY_SUMMARY_ENDPOINT = '/summary'
 export const ORAMA_PROXY_EMBEDDINGS_ENDPOINT = '/query'
 
+export const ORAMA_SEARCH_BASE = 'https://cloud.orama.run/v1/indexes'
+
 export const LOCAL_STORAGE_USER_ID_KEY = 'orama_user_id'
 export const LOCAL_STORAGE_SERVER_SIDE_SESSION_KEY = 'server-side-session'

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,6 +1,6 @@
 import { createId } from '@orama/cuid2'
 import sendBeacon from './sendBeacon.js'
-import { OramaInitResponse } from './types.js'
+import type { OramaInitResponse } from './types.js'
 import { LOCAL_STORAGE_USER_ID_KEY } from './constants.js'
 
 type ProfileConstructor = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,19 +39,27 @@ export interface IOramaClient {
   cache?: Partial<CacheConfig> | false
 }
 
+export interface IOramaClientMultiSearch extends Omit<IOramaClient, 'api_key' | 'endpoint'> {
+  endpoint?: string
+  indexes: {
+    api_key: string
+    id: string
+  }[]
+}
+
 export interface TelemetryConfig {
   flushInterval: number
   flushSize: number
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// biome-ignore lint/suspicious/noEmptyInterface: <explanation>
 export interface CacheConfig {}
 
 export interface HeartBeatConfig {
   frequency: number
 }
 
-export type Endpoint = 'search' | 'init' | 'info' | 'health' | 'vector-search2'
+export type Endpoint = 'search' | 'init' | 'info' | 'health' | 'vector-search2' | 'multi_search' | 'init_multi_search'
 
 export type Method = 'GET' | 'POST'
 


### PR DESCRIPTION
This adds experimental support for multi index search.

To perform multi_index search:

```js
const client = new OramaClient(
  indexes: [
    {
      id: "<Your Orama Cloud index id 1>",
      api_key: "<Your Orama Cloud API Key for index 1>",
    },
    {
      id: "<Your Orama Cloud index id 2>",
      api_key: "<Your Orama Cloud API Key for index 2>",
    },
    {
      id: "<Your Orama Cloud index id 3>",
      api_key: "<Your Orama Cloud API Key for index 3>",
    },
  ]
  );

const results = await client.search({
  term: "red leather shoes",
});
```